### PR TITLE
removing knob view from pedalRow

### DIFF
--- a/PedalCore/Views/PedalRow.swift
+++ b/PedalCore/Views/PedalRow.swift
@@ -20,6 +20,13 @@ struct PedalRow: View {
                 .font(.subheadline)
                 .foregroundStyle(.secondary)
             
+            HStack {
+                ForEach(pedal.knobs, id: \.id) {
+                    Text($0.name)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+            }
         }
     }
 }

--- a/PedalCore/Views/PedalRow.swift
+++ b/PedalCore/Views/PedalRow.swift
@@ -20,14 +20,6 @@ struct PedalRow: View {
                 .font(.subheadline)
                 .foregroundStyle(.secondary)
             
-            ScrollView(.horizontal) {
-                HStack(spacing: 30) {
-                    ForEach(pedal.knobs, id: \.name) { knob in
-                        KnobView(knob: knob)
-                    }
-                }
-                .padding(.horizontal, 10)
-            }
         }
     }
 }


### PR DESCRIPTION
As we agreed, removing knobs scrollview from pedalRow for a cleaner visualization of pedalList