### PR TITLE
Layout improvement

### DIFF
--- a/PedalCore/Views/HomeView.swift
+++ b/PedalCore/Views/HomeView.swift
@@ -58,11 +58,15 @@ public struct HomeView: View {
     @ViewBuilder
     private var emptyView: some View {
         VStack(alignment: .leading, spacing: 20) {
+            Spacer()
+            
             Text("None pedals registered yet")
                 .font(.headline)
             
             Text("You may add new pedals by tapping in the superior button")
                 .font(.subheadline)
+            
+            Spacer()
         }
         .foregroundStyle(.secondary)
         .font(.headline)


### PR DESCRIPTION
I've placed the text in the middle of the screen, when the pedal list is empty