### PR TITLE
Async save/load functions in JsonDataService

### DIFF
--- a/PedalCore/Providers/DataProviderProtocol.swift
+++ b/PedalCore/Providers/DataProviderProtocol.swift
@@ -11,5 +11,5 @@ protocol DataProviderProtocol<T> {
     associatedtype T
     
     func update(_: [T]) throws
-    func load(_: (_: [T]) -> Void) throws
+    func load(_: @escaping (_: [T]) -> Void) throws
 }

--- a/PedalCore/Providers/LocalDataProvider.swift
+++ b/PedalCore/Providers/LocalDataProvider.swift
@@ -24,7 +24,7 @@ class LocalDataProvider<T: Hashable>: DataProviderProtocol {
         try persistenceService.save(data)
     }
     
-    func load(_ onLoad: ([T]) -> Void) throws {
+    func load(_ onLoad: @escaping ([T]) -> Void) throws {
         try persistenceService.load { loadedData in
             self.data = loadedData
             onLoad(loadedData)

--- a/PedalCore/Services/JsonDataService.swift
+++ b/PedalCore/Services/JsonDataService.swift
@@ -22,28 +22,32 @@ public final class JsonDataService<T: Codable>: PersistenceProtocol where T: Has
     }
     
     public func save(_ data: [T]) throws {
-        do {
-            // convert data to json
-            let jsonData = try JSONEncoder().encode(data)
-            
-            // save json to fileURL
-            guard let fileUrl = self.fileUrl else {
-                throw ServiceError.noFileUrl("No valid file URL to write to.")
+        Task {
+            do {
+                // convert data to json
+                let jsonData = try JSONEncoder().encode(data)
+                
+                // save json to fileURL
+                guard let fileUrl = self.fileUrl else {
+                    throw ServiceError.noFileUrl("No valid file URL to write to.")
+                }
+                try jsonData.write(to: fileUrl)
             }
-            try jsonData.write(to: fileUrl)
         }
     }
     
-    public func load(_ onLoad: ([T]) -> Void) throws {
-        // get fileURL
-        guard let fileUrl = self.fileUrl else {
-            throw ServiceError.noFileUrl("No valid file URL to read from.")
+    public func load(_ onLoad: @escaping ([T]) -> Void) throws {
+        Task {
+            // get fileURL
+            guard let fileUrl = self.fileUrl else {
+                throw ServiceError.noFileUrl("No valid file URL to read from.")
+            }
+            
+            // load from fileUrl
+            let jsonData = try Data(contentsOf: fileUrl)
+            let decodedData = try JSONDecoder().decode([T].self, from: jsonData)
+            onLoad(decodedData)
         }
-        
-        // load from fileUrl
-        let jsonData = try Data(contentsOf: fileUrl)
-        let decodedData = try JSONDecoder().decode([T].self, from: jsonData)
-        onLoad(decodedData)
     }
     
     enum ServiceError: Error {

--- a/PedalCore/Services/PersistenceProtocol.swift
+++ b/PedalCore/Services/PersistenceProtocol.swift
@@ -11,5 +11,5 @@ public protocol PersistenceProtocol<T> {
     associatedtype T where T: Hashable
     
     func save(_: [T]) throws
-    func load(_: (_: [T]) -> Void) throws
+    func load(_: @escaping (_: [T]) -> Void) throws
 }

--- a/PedalCore/ViewModels/Songs/SongsListViewModel.swift
+++ b/PedalCore/ViewModels/Songs/SongsListViewModel.swift
@@ -54,7 +54,7 @@ public class SongsListViewModel: ObservableObject {
     private func load() {
         do {
             try provider.load { songs in
-                allSongs = songs
+                self.allSongs = songs
             }
         } catch {
             isShowingAlert = true

--- a/PedalCoreTests/Mock/MockPersistanceService.swift
+++ b/PedalCoreTests/Mock/MockPersistanceService.swift
@@ -29,7 +29,7 @@ class MockPersistanceService<T: Codable>: PersistenceProtocol where T: Hashable 
         try service.save(data)
     }
     
-    func load(_ onLoad: ([T]) -> Void) throws {
+    func load(_ onLoad: @escaping ([T]) -> Void) throws {
         if shouldThrowLoading {
             throw MockedError.failedLoad("Error loading data")
         }


### PR DESCRIPTION
## Changes
- Using swift Tasks to dispatch read/write calls into the background queue.
- Added @ escaping to the onLoad closure parameter to make it available inside Task blocks.
- Added @ escaping to the protocols definitions.

### Screenshots
N/A

## Affected Areas:
- PersistenceProtocol & JsonDataService
- DataProviderProtocol & LocalDataProvider

## Test Procedure:
Test that LocalDataProvider works normally, run unit tests

## Unit Tests:
- Added @ escaping to load func on MockPersistenceService.