### PR TITLE
bottom padding added

### DIFF
--- a/PedalCore/Views/Songs/SongList/SongsListView.swift
+++ b/PedalCore/Views/Songs/SongList/SongsListView.swift
@@ -94,6 +94,7 @@ public struct SongsListView: View {
                 Image(systemName: "eyes")
             }
         }
+        .padding(.bottom)
     }
 }
 


### PR DESCRIPTION
## Changes
- I've conformed the footButtonsView in SongsListView to be at the same positions as showed in HomeView
- It's not a definitive fix, because we need to go further and understand why footButtonsView is shown in different position in those two Views

### Screenshots
https://github.com/matheusberger/pb-ios/assets/109837482/4657856e-3dc4-4265-9f4f-25b9d55a5384

## Affected Areas:
- SongsListView's layout

## Test Procedure:
- N/A

## Unit Tests:
- N/A
