### PR TITLE
Use pedal provider

### DIFF
--- a/PedalBoard.xcodeproj/project.pbxproj
+++ b/PedalBoard.xcodeproj/project.pbxproj
@@ -327,8 +327,8 @@
 			children = (
 				0C12A4312B05A101005D8F3D /* SongDetailView.swift */,
 				0C46ED6A2B1638E500DBFCBB /* SongDetailViewModel.swift */,
-				0C34AEBF2B0F08E400ED3FDC /* SelectPedalRow.swift */,
 				0C12A4222B05494A005D8F3D /* SelectPedalView.swift */,
+				0C34AEBF2B0F08E400ED3FDC /* SelectPedalRow.swift */,
 			);
 			path = Detail;
 			sourceTree = "<group>";

--- a/PedalBoard/PedalBoardApp.swift
+++ b/PedalBoard/PedalBoardApp.swift
@@ -13,7 +13,9 @@ struct PedalBoardApp: App {
     var body: some Scene {
         WindowGroup {
             let viewModel = Song.ListViewModel()
-            Song.ListView(viewModel: viewModel)
+            NavigationStack {
+                Song.ListView(viewModel: viewModel)
+            }
         }
     }
 }

--- a/PedalBoard/Songs/Detail/SelectPedalView.swift
+++ b/PedalBoard/Songs/Detail/SelectPedalView.swift
@@ -10,52 +10,52 @@ import SwiftUI
 struct SelectPedalView: View {
     @Environment(\.dismiss) var dismiss
     
-    @State var availablePedals: [Pedal.Model]
-    @State var pedalList: [Pedal.Model]
+    @State var allPedals: [Pedal.Model]
+    @State var selectedPedals: [Pedal.Model]
     @State var searchText: String = ""
     var onDismiss: ([Pedal.Model]) -> Void
     
-    init(availablePedals: [Pedal.Model] = Pedal.pedalSample(), alreadyChosenPedals: [Pedal.Model],
+    init(allPedals: [Pedal.Model], selectedPedals: [Pedal.Model],
          onDismiss: @escaping ([Pedal.Model]) -> Void) {
-        self._availablePedals = State(initialValue: availablePedals)
-        self._pedalList = State(initialValue: alreadyChosenPedals)
+        self._allPedals = State(initialValue: allPedals)
+        self._selectedPedals = State(initialValue: selectedPedals)
         self.onDismiss = onDismiss
     }
     
     
     public var filteredPedals: [Pedal.Model] {
         if searchText.isEmpty {
-            return availablePedals
+            return allPedals
         } else {
-            return availablePedals.filter { pedal in
+            return allPedals.filter { pedal in
                 pedal.name.localizedCaseInsensitiveContains(searchText) || pedal.brand.localizedCaseInsensitiveContains(searchText) ||
-                availablePedals.contains(pedal)
+                allPedals.contains(pedal)
             }
         }
     }
     
     private func toggleSelection(for pedal: Pedal.Model) {
-        if pedalList.contains(pedal) {
-            pedalList.removeAll(where: {$0 == pedal})
+        if selectedPedals.contains(pedal) {
+            selectedPedals.removeAll(where: {$0 == pedal})
         } else {
-            pedalList.append(pedal)
+            selectedPedals.append(pedal)
         }
     }
     
     public func shouldBeIndicatedWithLight(for pedal: Pedal.Model) -> Bool {
-        return pedalList.contains(pedal)
+        return selectedPedals.contains(pedal)
     }
     
     var body: some View {
             Group {
-                if availablePedals.isEmpty {
+                if allPedals.isEmpty {
                     emptyView
                 } else {
                     pedalContentList
                 }
             }
             .onDisappear {
-                onDismiss(pedalList)
+                onDismiss(selectedPedals)
             }
             .navigationTitle("Select pedals")
             .toolbar {
@@ -118,7 +118,7 @@ struct SelectPedalView: View {
 
 struct SelectPedalView_Previews: PreviewProvider {
     static var previews: some View {
-        SelectPedalView(alreadyChosenPedals: []) { _ in
+        SelectPedalView(allPedals: Pedal.pedalSample(), selectedPedals: []) { _ in
             
         }
     }

--- a/PedalBoard/Songs/Detail/SelectPedalView.swift
+++ b/PedalBoard/Songs/Detail/SelectPedalView.swift
@@ -47,25 +47,24 @@ struct SelectPedalView: View {
     }
     
     var body: some View {
-            Group {
-                if allPedals.isEmpty {
-                    emptyView
-                } else {
-                    pedalContentList
+        Group {
+            if allPedals.isEmpty {
+                emptyView
+            } else {
+                pedalContentList
+            }
+        }
+        .onDisappear {
+            onDismiss(selectedPedals)
+        }
+        .navigationTitle("Select pedals")
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                Button("Done") {
+                    dismiss()
                 }
             }
-            .onDisappear {
-                onDismiss(selectedPedals)
-            }
-            .navigationTitle("Select pedals")
-            .toolbar {
-                ToolbarItem(placement: .primaryAction) {
-                    Button("Done") {
-
-                        dismiss()
-                    }
-                }
-            }
+        }
     }
     
     @ViewBuilder
@@ -92,7 +91,7 @@ struct SelectPedalView: View {
                     ForEach(filteredPedals, id: \.signature) { pedal in
                         Button {
                             withAnimation {
-                               toggleSelection(for: pedal)
+                                toggleSelection(for: pedal)
                             }
                             
                         } label: {
@@ -106,11 +105,11 @@ struct SelectPedalView: View {
                 .buttonStyle(.plain)
                 
             }
-        header: {
-            Text("Your PedalBoard")
-        } footer: {
-            Text("You can add new pedals on pedal List view")
-        }
+            header: {
+                Text("Your PedalBoard")
+            } footer: {
+                Text("You can add new pedals on pedal List view")
+            }
         }
     }
 }

--- a/PedalBoard/Songs/Detail/SongDetailView.swift
+++ b/PedalBoard/Songs/Detail/SongDetailView.swift
@@ -200,10 +200,8 @@ extension Song {
         
         @ViewBuilder
         private var sheetSelectPedalsView: some View {
-            SelectPedalView(alreadyChosenPedals: viewModel.pedalsUsed) { selectedPedals in
-                withAnimation {
-                    viewModel.userDidSelectNewPedals(pedals: selectedPedals)
-                }
+            withAnimation {
+                viewModel.selectPedalView
             }
         }
     }

--- a/PedalBoard/Songs/Detail/SongDetailView.swift
+++ b/PedalBoard/Songs/Detail/SongDetailView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import PedalCore
 
 extension Song {
     struct DetailView: View {
@@ -209,8 +210,10 @@ extension Song {
 
 struct SongDetailView_Previews: PreviewProvider {
     static var previews: some View {
+        let persistence = JsonDataService<Pedal.Model>(fileName: "Preview")
+        let provider =  LocalDataProvider<Pedal.Model>(persistence: persistence)
         NavigationView {
-            Song.DetailView(viewModel: Song.DetailViewModel(song: Song.getSample().first!))
+            Song.DetailView(viewModel: Song.DetailViewModel(song: Song.getSample().first!, pedalProvider: provider))
         }
     }
 }

--- a/PedalBoard/Songs/Detail/SongDetailViewModel.swift
+++ b/PedalBoard/Songs/Detail/SongDetailViewModel.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import PedalCore
 
 extension Song {
     class DetailViewModel: ObservableObject {
@@ -26,8 +27,11 @@ extension Song {
         
         weak var delegate: EditDelegate?
         
-        init(song: Song.Model, delegate: EditDelegate? = nil) {
+        private let pedalProvider: any DataProviderProtocol<Pedal.Model>
+        
+        init(song: Song.Model, pedalProvider: any DataProviderProtocol<Pedal.Model>, delegate: EditDelegate? = nil) {
             self.song = song
+            self.pedalProvider = pedalProvider
             self.delegate = delegate
         }
         
@@ -53,7 +57,7 @@ extension Song {
         }
         
         var selectPedalView: SelectPedalView {
-            SelectPedalView(allPedals: [], selectedPedals: pedalsUsed) { [self] selectedPedals in
+            SelectPedalView(allPedals: pedalProvider.data, selectedPedals: pedalsUsed) { [self] selectedPedals in
                 userDidSelectNewPedals(pedals: selectedPedals)
             }
         }

--- a/PedalBoard/Songs/Detail/SongDetailViewModel.swift
+++ b/PedalBoard/Songs/Detail/SongDetailViewModel.swift
@@ -31,25 +31,31 @@ extension Song {
             self.delegate = delegate
         }
         
-        public var isInEditing: Bool {
+        var isInEditing: Bool {
             return state != .presentation
         }
         
-        public var isInPresentationMode: Bool {
+        var isInPresentationMode: Bool {
             return state == .presentation
         }
         
         
-        public var isInEditingSongMode: Bool {
+        var isInEditingSongMode: Bool {
             return state == .editingSong
         }
         
-        public var isInEditingKnobsMode: Bool {
+        var isInEditingKnobsMode: Bool {
             return state == .editingKnobs
         }
         
         var pedalsUsed: [Pedal.Model]  {
             return song.pedals
+        }
+        
+        var selectPedalView: SelectPedalView {
+            SelectPedalView(allPedals: [], selectedPedals: pedalsUsed) { [self] selectedPedals in
+                userDidSelectNewPedals(pedals: selectedPedals)
+            }
         }
         
         public func saveButtonPressed() {

--- a/PedalBoard/Songs/Edit/SongEditView.swift
+++ b/PedalBoard/Songs/Edit/SongEditView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import PedalCore
 
 extension Song {
     struct EditView: View {
@@ -72,8 +73,10 @@ extension Song {
             .navigationTitle("Add new song")
             .navigationBarTitleDisplayMode(.inline)
             .sheet(isPresented: $viewModel.isPresentingSheet) {
-                SelectPedalView(allPedals: [], selectedPedals: viewModel.pedalList) { selectedPedals in
-                    viewModel.updateSelectedPedals(selectedPedals)
+                NavigationView {
+                    withAnimation {
+                        viewModel.selectPedalView
+                    }
                 }
             }
             .alert("Failed to save pedal", isPresented: $viewModel.isPresentingAlert) {
@@ -86,8 +89,9 @@ extension Song {
 
 struct CreateSongView_Previews: PreviewProvider {
     static var previews: some View {
+        let viewModel = Song.EditViewModel(pedalProvider: LocalDataProvider<Pedal.Model>(persistence: JsonDataService(fileName: "Preview")))
         NavigationStack {
-            Song.EditView(viewModel: Song.EditViewModel())
+            Song.EditView(viewModel: viewModel)
         }
     }
 }

--- a/PedalBoard/Songs/Edit/SongEditView.swift
+++ b/PedalBoard/Songs/Edit/SongEditView.swift
@@ -11,73 +11,69 @@ extension Song {
     struct EditView: View {
         
         @ObservedObject var viewModel: EditViewModel
-
+        
         
         init(viewModel: EditViewModel) {
             self.viewModel = viewModel
         }
         
         var body: some View {
-            NavigationView {
-                List {
-                    Section {
-                        TextField("Song name", text: $viewModel.songName, prompt: Text("Song name"))
-                        TextField("Band name", text: $viewModel.bandName, prompt: Text("Artist name"))
-                    } header: {
-                        Text("Song info")
-                    } footer: {
-                        Text("You song must have a name and a artist")
-                    }
-                    
-                    Section {
-                        ForEach($viewModel.pedalList) { $pedal in
-                            VStack {
-                                VStack(alignment: .leading) {
-                                    Text(pedal.name)
-                                        .font(.headline)
-                                        .foregroundStyle(.primary)
-                                    
-                                    Pedal.KnobGridView(knobs: $pedal.knobs)
-                                    
-                                }
+            List {
+                Section {
+                    TextField("Song name", text: $viewModel.songName, prompt: Text("Song name"))
+                    TextField("Band name", text: $viewModel.bandName, prompt: Text("Artist name"))
+                } header: {
+                    Text("Song info")
+                } footer: {
+                    Text("You song must have a name and a artist")
+                }
+                
+                Section {
+                    ForEach($viewModel.pedalList) { $pedal in
+                        VStack {
+                            VStack(alignment: .leading) {
+                                Text(pedal.name)
+                                    .font(.headline)
+                                    .foregroundStyle(.primary)
+                                
+                                Pedal.KnobGridView(knobs: $pedal.knobs)
+                                
                             }
-                            .contextMenu(menuItems: {
-                                Button(role: .destructive) {
-                                    viewModel.removePedal(pedal)
-                                } label: {
-                                    Label("Delete", systemImage: "trash.fill")
-                                }
-                            })
                         }
-                        .onDelete(perform: { indexSet in
-                            viewModel.removePedal(at: indexSet)
+                        .contextMenu(menuItems: {
+                            Button(role: .destructive) {
+                                viewModel.removePedal(pedal)
+                            } label: {
+                                Label("Delete", systemImage: "trash.fill")
+                            }
                         })
-                        
-                        Button {
-                            viewModel.attachPedalPressed()
-                        } label: {
-                            Text("Attach pedal")
-                                .foregroundStyle(Color.accentColor)
-                        }
-                        
-                    } header: {
-                        Text("Pedalboard")
+                    }
+                    .onDelete(perform: { indexSet in
+                        viewModel.removePedal(at: indexSet)
+                    })
+                    
+                    Button {
+                        viewModel.attachPedalPressed()
+                    } label: {
+                        Text("Attach pedal")
+                            .foregroundStyle(Color.accentColor)
                     }
                     
-                    Section("Save") {
-                        Button("Add Song") {
-                            viewModel.addSongPressed()
-                        }
+                } header: {
+                    Text("Pedalboard")
+                }
+                
+                Section("Save") {
+                    Button("Add Song") {
+                        viewModel.addSongPressed()
                     }
                 }
-                .navigationTitle("Add new song")
-                .navigationBarTitleDisplayMode(.inline)
             }
+            .navigationTitle("Add new song")
+            .navigationBarTitleDisplayMode(.inline)
             .sheet(isPresented: $viewModel.isPresentingSheet) {
-                NavigationView {
-                    SelectPedalView(alreadyChosenPedals: viewModel.pedalList) { selectedPedals in
-                        viewModel.updateSelectedPedals(selectedPedals)
-                    }
+                SelectPedalView(allPedals: [], selectedPedals: viewModel.pedalList) { selectedPedals in
+                    viewModel.updateSelectedPedals(selectedPedals)
                 }
             }
             .alert("Failed to save pedal", isPresented: $viewModel.isPresentingAlert) {
@@ -90,6 +86,8 @@ extension Song {
 
 struct CreateSongView_Previews: PreviewProvider {
     static var previews: some View {
-        Song.EditView(viewModel: Song.EditViewModel())
+        NavigationStack {
+            Song.EditView(viewModel: Song.EditViewModel())
+        }
     }
 }

--- a/PedalBoard/Songs/Edit/SongEditViewModel.swift
+++ b/PedalBoard/Songs/Edit/SongEditViewModel.swift
@@ -7,13 +7,22 @@
 
 import Foundation
 import SwiftUI
+import PedalCore
 
 extension Song {
     class EditViewModel: ObservableObject {
         
         weak var delegate: EditDelegate?
         
-        var availablePedals: [Pedal.Model] = Pedal.pedalSample()
+        var availablePedals: [Pedal.Model] {
+            return provider.data
+        }
+        
+        var selectPedalView: SelectPedalView {
+            SelectPedalView(allPedals: availablePedals, selectedPedals: pedalList) { [self] selectedPedals in
+                updateSelectedPedals(selectedPedals)
+            }
+        }
         
         @Published public var songName: String = ""
         @Published var bandName: String = ""
@@ -24,7 +33,10 @@ extension Song {
         @Published var isPresentingAlert: Bool = false
         @Published var alertMessage: String = ""
         
-        init(delegate: EditDelegate? = nil) {
+        private let provider: any DataProviderProtocol<Pedal.Model>
+        
+        init(pedalProvider: any DataProviderProtocol<Pedal.Model>, delegate: EditDelegate? = nil) {
+            self.provider = pedalProvider
             self.delegate = delegate
         }
         

--- a/PedalBoard/Songs/List/SongListView.swift
+++ b/PedalBoard/Songs/List/SongListView.swift
@@ -18,29 +18,27 @@ extension Song {
         }
         
         public var body: some View {
-            NavigationView {
-                VStack {
-                    switch viewModel.state {
-                    case .empty:
-                        emptyView
-                        
-                    case .content:
-                        listView
-                    }
+            VStack {
+                switch viewModel.state {
+                case .empty:
+                    emptyView
                     
-                    footerButtonsView
+                case .content:
+                    listView
                 }
-                .navigationTitle("My Songs")
-                .toolbar {
-                    NavigationLink {
-                        Pedal.ListView(viewModel: viewModel.pedalViewModel)
-                    } label: {
-                        Image(systemName: "lanyardcard.fill")
-                    }
+                
+                footerButtonsView
+            }
+            .navigationTitle("My Songs")
+            .toolbar {
+                NavigationLink {
+                    Pedal.ListView(viewModel: viewModel.pedalViewModel)
+                } label: {
+                    Image(systemName: "lanyardcard.fill")
                 }
-                .sheet(isPresented: $viewModel.isShowingSheet) {
-                    Song.EditView(viewModel: Song.EditViewModel(delegate: self.viewModel))
-                }
+            }
+            .sheet(isPresented: $viewModel.isShowingSheet) {
+                Song.EditView(viewModel: Song.EditViewModel(delegate: self.viewModel))
             }
         }
         
@@ -80,7 +78,7 @@ extension Song {
                             }
                         }
                 }
-               
+                
             }
             .searchable(text: $viewModel.searchText, prompt: "Search a song or artist")
         }
@@ -107,6 +105,8 @@ struct SongsView_Previews: PreviewProvider {
         let persistence = JsonDataService<Song.Model>(fileName: "SongPreview")
         let provider =  LocalDataProvider<Song.Model>(persistence: persistence)
         let viewModel = Song.ListViewModel(songProvider: provider)
-        Song.ListView(viewModel: viewModel)
+        NavigationStack {
+            Song.ListView(viewModel: viewModel)
+        }
     }
 }

--- a/PedalBoard/Songs/List/SongListView.swift
+++ b/PedalBoard/Songs/List/SongListView.swift
@@ -32,13 +32,13 @@ extension Song {
             .navigationTitle("My Songs")
             .toolbar {
                 NavigationLink {
-                    Pedal.ListView(viewModel: viewModel.pedalViewModel)
+                    viewModel.pedalView
                 } label: {
                     Image(systemName: "lanyardcard.fill")
                 }
             }
             .sheet(isPresented: $viewModel.isShowingSheet) {
-                Song.EditView(viewModel: Song.EditViewModel(delegate: self.viewModel))
+                viewModel.editView
             }
         }
         
@@ -59,7 +59,7 @@ extension Song {
         private var listView: some View {
             List(viewModel.songs, id:\.signature) { song in
                 NavigationLink {
-                    Song.DetailView(viewModel: Song.DetailViewModel(song: song, delegate: self.viewModel))
+                    viewModel.detailView(song)
                 } label: {
                     ListRow(song: song)
                         .contextMenu(menuItems: {

--- a/PedalBoard/Songs/List/SongListViewModel.swift
+++ b/PedalBoard/Songs/List/SongListViewModel.swift
@@ -36,8 +36,19 @@ extension Song {
         
         var alert: Alert?
         
-        var pedalViewModel: Pedal.ListViewModel {
-            return Pedal.ListViewModel(provider: pedalProvider)
+        var pedalView: Pedal.ListView {
+            let viewModel = Pedal.ListViewModel(provider: pedalProvider)
+            return Pedal.ListView(viewModel: viewModel)
+        }
+        
+        var editView: EditView {
+            let viewModel = EditViewModel(pedalProvider: pedalProvider, delegate: self)
+            return Song.EditView(viewModel: viewModel)
+        }
+        
+        func detailView(_ song: Song.Model) -> DetailView {
+            let viewModel = DetailViewModel(song: song, pedalProvider: pedalProvider, delegate: self)
+            return DetailView(viewModel: viewModel)
         }
         
         private var songProvider: LocalDataProvider<Song.Model>
@@ -104,14 +115,6 @@ extension Song {
         
         func deleteSong(_ deletedSong: Song.Model) {
             allSongs = allSongs.filter { $0 != deletedSong }
-        }
-        
-        func populateSongs() {
-            let songsDemo = Song.getSample()
-            
-            songsDemo.forEach {
-                allSongs.append($0)
-            }
         }
     }
 }

--- a/PedalBoardTests/ViewModels/SongDetailViewModelTests.swift
+++ b/PedalBoardTests/ViewModels/SongDetailViewModelTests.swift
@@ -6,6 +6,7 @@
 //
 
 import XCTest
+import PedalCore
 @testable import PedalBoard
 
 final class SongDetailViewModelTests: XCTestCase {
@@ -18,7 +19,8 @@ final class SongDetailViewModelTests: XCTestCase {
         let song = Song.Model(name: "Example", artist: "Example", pedals: [Pedal.Model(name: "pedal1", brand: "brand1", knobs: [Pedal.Knob(name: "Leve")])])
         
         delegate = MockSongEditDelegate()
-        viewModel = Song.DetailViewModel(song: song, delegate: delegate)
+        let provider = LocalDataProvider<Pedal.Model>(persistence: JsonDataService(fileName: "Preview"))
+        viewModel = Song.DetailViewModel(song: song, pedalProvider: provider, delegate: delegate)
         
     }
     

--- a/PedalBoardTests/ViewModels/SongEditViewModelTests.swift
+++ b/PedalBoardTests/ViewModels/SongEditViewModelTests.swift
@@ -6,6 +6,7 @@
 //
 
 import XCTest
+import PedalCore
 @testable import PedalBoard
 
 final class SongEditViewModelTests: XCTestCase {
@@ -15,8 +16,8 @@ final class SongEditViewModelTests: XCTestCase {
     
     override func setUpWithError() throws {
         delegate = MockSongEditDelegate()
-        viewModel = Song.EditViewModel(delegate: delegate)
-        
+        let provider = LocalDataProvider<Pedal.Model>(persistence: JsonDataService(fileName: "Preview"))
+        viewModel = Song.EditViewModel(pedalProvider: provider, delegate: delegate)
     }
     
     func testViewModelStartsWithEmptyFields() {

--- a/PedalCore/Providers/DataProviderProtocol.swift
+++ b/PedalCore/Providers/DataProviderProtocol.swift
@@ -7,8 +7,10 @@
 
 import Foundation
 
-protocol DataProviderProtocol<T> {
+public protocol DataProviderProtocol<T> {
     associatedtype T
+    
+    var data: [T] { get }
     
     func update(_: [T]) throws
     func load(_: @escaping (_: [T]) -> Void) throws

--- a/PedalCore/Providers/LocalDataProvider.swift
+++ b/PedalCore/Providers/LocalDataProvider.swift
@@ -8,11 +8,11 @@
 import Foundation
 
 public class LocalDataProvider<T: Hashable>: DataProviderProtocol {
-    typealias T = T
+    public typealias T = T
     
     private let persistence: any PersistenceProtocol<T>
     
-    private(set) var data: [T]
+    private(set) public var data: [T]
     
     public init(persistence: any PersistenceProtocol<T>) {
         self.persistence = persistence


### PR DESCRIPTION
## Changes
Refactored code to use data directly from the PedalProvider

### Screenshots
N/A

## Affected Areas:
SongEditView and SongDetailView

## Test Procedure:
1. Add a Pedal
2. Create new song
3. Tap Attach Pedal
4. Verify the pedal you created appears in the list alongside all other pedals
5. Add Song
6. Tap the song to navigate to the Song's detail view
7. Tap the edit icon
8. Tap "Change pedals"
9. Verify the pedal you created appears in the list alongside all other pedals

## Unit Tests:
N/A
