### PR TITLE
Save song button

### DIFF
--- a/PedalBoard/Pedal/List/PedalListView.swift
+++ b/PedalBoard/Pedal/List/PedalListView.swift
@@ -89,7 +89,7 @@ extension Pedal {
                     .foregroundStyle(colorScheme == .light ? Color.white : Color.black)
             }
             .buttonStyle(.borderedProminent)
-            .padding(.bottom)
+            .padding(.top)
         }
     }
 }

--- a/PedalBoard/Songs/List/SongListView.swift
+++ b/PedalBoard/Songs/List/SongListView.swift
@@ -97,7 +97,7 @@ extension Song {
                     .foregroundStyle(colorScheme == .light ? Color.white : Color.black)
             }
             .buttonStyle(.borderedProminent)
-            .padding(.bottom)
+            .padding(.top)
         }
     }
 }

--- a/PedalBoardTests/ViewModels/PedalEditViewModelTests.swift
+++ b/PedalBoardTests/ViewModels/PedalEditViewModelTests.swift
@@ -55,7 +55,7 @@ final class PedalEditViewModelTests: XCTestCase {
     }
     
     func testOnSaveIsCalledWithNewPedal() async {
-        var onSaveCalledExpectation = XCTestExpectation(description: "onSave callback was called")
+        let onSaveCalledExpectation = XCTestExpectation(description: "onSave callback was called")
         
         viewModel = Pedal.EditViewModel() { _ in
             onSaveCalledExpectation.fulfill()

--- a/PedalBoardTests/ViewModels/PedalListViewModelsTests.swift
+++ b/PedalBoardTests/ViewModels/PedalListViewModelsTests.swift
@@ -22,7 +22,6 @@ final class PedalListViewModelsTests: XCTestCase {
     }
     
     @MainActor func testRemovePedalDeletsItFromPedalArray() {
-
         // given
         let pedal1 = Pedal(name: "name1", brand: "brand1", knobs: [])
         let pedal2 = Pedal(name: "name2", brand: "brand2", knobs: [])
@@ -37,7 +36,6 @@ final class PedalListViewModelsTests: XCTestCase {
     }
     
     @MainActor func testSearchWithValidInfoFiltersShowPedals() {
-        
         let pedal1 = Pedal(name: "Space Echo", brand: "Boss", knobs: [])
         let pedal2 = Pedal(name: "Tube Screamer", brand: "Ibanez", knobs: [])
         viewModel.allPedals = [pedal1, pedal2]
@@ -49,7 +47,6 @@ final class PedalListViewModelsTests: XCTestCase {
     }
     
     @MainActor func testSearchWithBrandNameFiltersPedals() {
-        
         let pedal1 = Pedal(name: "Space Echo", brand: "Boss", knobs: [])
         let pedal2 = Pedal(name: "Overdrive 3", brand: "Boss", knobs: [])
         let pedal3 = Pedal(name: "Tube Screamer", brand: "Ibanez", knobs: [])
@@ -60,11 +57,9 @@ final class PedalListViewModelsTests: XCTestCase {
         XCTAssertTrue(viewModel.filteredPedals.contains(where: {$0 == pedal1}))
         XCTAssertTrue(viewModel.filteredPedals.contains(where: {$0 == pedal2}))
         XCTAssertFalse(viewModel.filteredPedals.contains(where: {$0 == pedal3}))
-        
     }
     
     @MainActor func testSeachWithWrongInfoFiltersEveryPedals() {
-        
         let pedal1 = Pedal(name: "Space Echo", brand: "Boss", knobs: [])
         let pedal2 = Pedal(name: "Tube Screamer", brand: "Ibanez", knobs: [])
         viewModel.allPedals = [pedal1, pedal2]
@@ -76,7 +71,6 @@ final class PedalListViewModelsTests: XCTestCase {
     
     
     @MainActor func testAddPedalWithValidInfoAppendsToPedalArray() {
-        
         let name = "pedalName"
         let brand = "brand"
         let knobs = [Pedal.Knob(name: "Knob1"), Pedal.Knob(name: "Knob2")]

--- a/PedalBoardTests/ViewModels/SongEditViewModelTests.swift
+++ b/PedalBoardTests/ViewModels/SongEditViewModelTests.swift
@@ -54,7 +54,7 @@ final class SongEditViewModelTests: XCTestCase {
     }
     
     func testOnSaveIsCalled() async {
-        var onSaveCalledExpectation = XCTestExpectation(description: "completion handler was called")
+        let onSaveCalledExpectation = XCTestExpectation(description: "completion handler was called")
         
         viewModel = Song.EditViewModel(availablePedals: availablePedals) { _ in
             onSaveCalledExpectation.fulfill()

--- a/PedalCoreTests/Providers/LocalDataProviderTests.swift
+++ b/PedalCoreTests/Providers/LocalDataProviderTests.swift
@@ -24,9 +24,10 @@ final class LocalDataProviderTests: XCTestCase {
     }
     
     func testLoad() async throws {
-        var loadSuccessExpectation = XCTestExpectation(description: "successfully loaded data")
+        let loadSuccessExpectation = XCTestExpectation(description: "successfully loaded data")
         let expectedSongs = Song.getSample()
         try provider?.update(expectedSongs)
+        
         try provider?.load{ songs in
             if songs.count == expectedSongs.count {
                 loadSuccessExpectation.fulfill()


### PR DESCRIPTION
## Changes

### Song.EditView
- Save song button is now a primary action button
- Added cancel button

### Screenshots
![Simulator Screenshot - iPhone 15 Pro - 2024-06-12 at 19 33 14](https://github.com/matheusberger/pb-ios/assets/24720744/cc84d6a3-62e8-41ea-80b3-0d74d36ed90d)

## Affected Areas:
SongEditView

## Test Procedure:
Verify the save button is in the same format as "new song" and "new pedal" buttons

## Unit Tests:
n/a
