### PR TITLE
PedalEditView with primary and cancel buttons

### DIFF
--- a/PedalBoard/Pedal/Edit/PedalEditView.swift
+++ b/PedalBoard/Pedal/Edit/PedalEditView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 extension Pedal {
     struct EditView: View {
         @EnvironmentObject private var navigationModel: NavigationModel
+        @Environment(\.colorScheme) var colorScheme
         @ObservedObject var viewModel: EditViewModel
         
         init(viewModel: EditViewModel) {
@@ -17,65 +18,87 @@ extension Pedal {
         }
         
         var body: some View {
-            List {
-                Section("Name") {
-                    TextField("Pedal name:", text: $viewModel.pedalName, prompt: Text("Name your pedal here") )
-                }
-                
-                Section("Brand") {
-                    TextField("Pedal brand:", text: $viewModel.brandName, prompt: Text("Name the pedal brand here"))
-                }
-                
-                Section("Knobs") {
-                    ForEach(viewModel.knobs, id: \.id) { knob in
-                        if let index = viewModel.knobs.firstIndex(where: {$0.id == knob.id}) {
-                            HStack {
-                                TextField("Knob name:", text: $viewModel.knobs[index].name, prompt: Text("Name the knob here"))
-                                    .submitLabel(.return)
-                                
-                                if viewModel.knobs[index].name.isEmpty {
-                                    Button {
-                                        UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
-                                        viewModel.removeKnob(at: IndexSet(integer: index))
-                                    } label: {
-                                        Image(systemName: "xmark.circle")
-                                            .imageScale(.medium)
-                                            .frame(width: 20, height: 20)
-                                    }
-                                }
-                            }
+            VStack {
+                List {
+                    Section("Name") {
+                        TextField("Pedal name:", text: $viewModel.pedalName, prompt: Text("Name your pedal here") )
+                    }
+                    
+                    Section("Brand") {
+                        TextField("Pedal brand:", text: $viewModel.brandName, prompt: Text("Name the pedal brand here"))
+                    }
+                    
+                    Section("Knobs") {
+                        ForEach(viewModel.knobs, id: \.id) { knob in
+                            knobDisplay(knob)
+                        }
+                        .onDelete(perform: { indexSet in
+                            viewModel.removeKnob(at: indexSet)
+                        })
+                        
+                        Button {
+                            viewModel.addKnobPressed()
+                        } label: {
+                            Text("Add knob")
                         }
                     }
-                    .onDelete(perform: { indexSet in
-                        viewModel.removeKnob(at: indexSet)
-                    })
-                    
-                    Button {
-                        viewModel.addKnobPressed()
-                    } label: {
-                        Text("Add knob")
-                    }
                 }
                 
-                Button {
-                    Task {
-                        await viewModel.save()
-                    }
-                } label: {
-                    Text("SAVE PEDAL")
-                }
-                
-                Button(role: .destructive) {
-                    navigationModel.pop()
-                } label: {
-                    Text("Cancel")
-                }
+                footerButtons
             }
             .navigationTitle("New Pedal")
             .alert("Failed to save pedal", isPresented: $viewModel.isPresentingAlert) {
             } message: {
                 Text(viewModel.alertMessage)
             }
+        }
+        
+        @ViewBuilder
+        private func knobDisplay(_ knob: Knob) -> some View {
+            if let index = viewModel.knobs.firstIndex(where: {$0.id == knob.id}) {
+                HStack {
+                    TextField("Knob name:", text: $viewModel.knobs[index].name, prompt: Text("Name the knob here"))
+                        .submitLabel(.return)
+                    
+                    if viewModel.knobs[index].name.isEmpty {
+                        Button {
+                            UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+                            viewModel.removeKnob(at: IndexSet(integer: index))
+                        } label: {
+                            Image(systemName: "xmark.circle")
+                                .imageScale(.medium)
+                                .frame(width: 20, height: 20)
+                        }
+                    }
+                }
+            }
+        }
+        
+        private var footerButtons: some View {
+            VStack {
+                Button {
+                    Task {
+                        await viewModel.save()
+                    }
+                } label: {
+                    Text("SAVE PEDAL")
+                        .fontWeight(.bold)
+                        .frame(width: 250,height: 30)
+                        .foregroundStyle(colorScheme == .light ? Color.white : Color.black)
+                }
+                .buttonStyle(.borderedProminent)
+                
+                Button(role: .destructive) {
+                    Task {
+                        navigationModel.pop()
+                    }
+                } label: {
+                    Text("cancel")
+                        .frame(width: 250,height: 30)
+                }
+                .buttonStyle(.borderless)
+            }
+            .padding(.top)
         }
     }
 }


### PR DESCRIPTION
## Changes

### Pedal.EditView
- Save pedal button is now a primary action button
- Added cancel button

### Screenshots
![Simulator Screenshot - iPhone 15 Pro - 2024-06-12 at 19 45 30](https://github.com/matheusberger/pb-ios/assets/24720744/de159a49-ac84-47fb-857a-675937331057)


## Affected Areas:
PedalEditView

## Test Procedure:
Verify the save button is in the same format as "new song" and "new pedal" buttons

## Unit Tests:
n/a
